### PR TITLE
Fix mismatch in associationURI between server and client

### DIFF
--- a/server/src/main/java/broker/api/InstitutionRegistryController.java
+++ b/server/src/main/java/broker/api/InstitutionRegistryController.java
@@ -55,11 +55,11 @@ public class InstitutionRegistryController {
             }
         }
         boolean validAssociationURI = true;
-        String associationURI = enrollmentRequest.get("associationURI");
-        if (StringUtils.hasText(associationURI)) {
-            validAssociationURI = institutions.stream().anyMatch(institution -> institution.getAssociationsEndpoint().equals(associationURI));
+        String associationsURI = enrollmentRequest.get("associationsURI");
+        if (StringUtils.hasText(associationsURI)) {
+            validAssociationURI = institutions.stream().anyMatch(institution -> institution.getAssociationsEndpoint().equals(associationsURI));
             if (!validAssociationURI) {
-                LOG.info(String.format("Invalid associationURI '%s'. No institution with this associationsEndpoint", associationURI));
+                LOG.info(String.format("Invalid associationsURI '%s'. No institution with this associationsEndpoint", associationsURI));
             }
         }
         return Collections.singletonMap("valid", validPersonURI && validSchacHome && validAssociationURI);

--- a/server/src/main/java/broker/domain/EnrollmentRequest.java
+++ b/server/src/main/java/broker/domain/EnrollmentRequest.java
@@ -11,7 +11,7 @@ public class EnrollmentRequest implements Serializable {
 
     private String personURI;
     private PersonAuthentication personAuth;
-    private String associationURI;
+    private String associationsURI;
     private String homeInstitution;
     private String alliance;
     private String scope;


### PR DESCRIPTION
There was a mismatch in spelling for `associationsURI`. The server used `associationURI` (without the s), while the client expected `associationsURI`. 

The result of this was that the form parameters when redirecting to the intekenontvanger always had `undefined` as a value for `associationsURI`. Everything still worked because the intekenontvangers use the service registry to fetch the correct URI anyway. But still this would be good to fix.

Please double check this PR because Java is not my best programming language ;-)